### PR TITLE
Make the basic alarm face more similar to the stock Casio alarm

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -512,6 +512,14 @@ void movement_set_alarm_enabled(bool value) {
     movement_state.alarm_enabled = value;
 }
 
+bool movement_signal_enabled(void) {
+    return movement_state.signal_enabled;
+}
+
+void movement_set_signal_enabled(bool value) {
+    movement_state.signal_enabled = value;
+}
+
 bool movement_enable_tap_detection_if_available(void) {
     if (movement_state.has_lis2dw) {
         // configure tap duration threshold and enable Z axis

--- a/movement.h
+++ b/movement.h
@@ -284,8 +284,9 @@ typedef struct {
     // backup register stuff
     uint8_t next_available_backup_register;
 
-    // temporary alarm enabled boolean, until we implement this in advisories
+    // temporary alarm and signal enabled boolean, until we implement this in advisories
     bool alarm_enabled;
+    bool signal_enabled;
 
     // boolean set if thermistor is detected
     bool has_thermistor;
@@ -373,6 +374,8 @@ void movement_store_settings(void);
 /// Worth considering a better way to handle this.
 bool movement_alarm_enabled(void);
 void movement_set_alarm_enabled(bool value);
+bool movement_signal_enabled(void);
+void movement_set_signal_enabled(bool value);
 
 // if the board has an accelerometer, these functions will enable or disable tap detection.
 bool movement_enable_tap_detection_if_available(void);

--- a/movement_faces.h
+++ b/movement_faces.h
@@ -27,6 +27,7 @@
 #include "clock_face.h"
 #include "beats_face.h"
 #include "world_clock_face.h"
+#include "stock_clock_face.h"
 #include "alarm_face.h"
 #include "advanced_alarm_face.h"
 #include "countdown_face.h"

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -2,6 +2,7 @@ SRCS += \
   ./watch-faces/clock/clock_face.c \
   ./watch-faces/clock/beats_face.c \
   ./watch-faces/clock/world_clock_face.c \
+  ./watch-faces/clock/stock_clock_face.c \
   ./watch-faces/clock/mars_time_face.c \
   ./watch-faces/clock/ish_face.c \
   ./watch-faces/complication/alarm_face.c \

--- a/watch-faces/clock/stock_clock_face.c
+++ b/watch-faces/clock/stock_clock_face.c
@@ -1,0 +1,271 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * MIT License
+ *
+ * Copyright © 2021-2023 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 David Keck <davidskeck@users.noreply.github.com>
+ * Copyright © 2022 TheOnePerson <a.nebinger@web.de>
+ * Copyright © 2023 Jeremy O'Brien <neutral@fastmail.com>
+ * Copyright © 2023 Mikhail Svarichevsky <3@14.by>
+ * Copyright © 2023 Wesley Aptekar-Cassels <me@wesleyac.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com>
+ * Copyright © 2025 Alessandro Genova
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "stock_clock_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+#include "watch_common_display.h"
+
+// 2.4 volts seems to offer adequate warning of a low battery condition?
+// refined based on user reports and personal observations; may need further adjustment.
+#ifndef CLOCK_FACE_LOW_BATTERY_VOLTAGE_THRESHOLD
+#define CLOCK_FACE_LOW_BATTERY_VOLTAGE_THRESHOLD 2400
+#endif
+
+static void clock_indicate(watch_indicator_t indicator, bool on) {
+    if (on) {
+        watch_set_indicator(indicator);
+    } else {
+        watch_clear_indicator(indicator);
+    }
+}
+
+static void clock_indicate_alarm() {
+    clock_indicate(WATCH_INDICATOR_SIGNAL, movement_alarm_enabled());
+}
+
+static void clock_indicate_time_signal() {
+    clock_indicate(WATCH_INDICATOR_BELL, movement_signal_enabled());
+}
+
+static void clock_indicate_24h() {
+    clock_indicate(WATCH_INDICATOR_24H, !!movement_clock_mode_24h());
+}
+
+static bool clock_is_pm(watch_date_time_t date_time) {
+    return date_time.unit.hour >= 12;
+}
+
+static void clock_indicate_pm(watch_date_time_t date_time) {
+    if (movement_clock_mode_24h()) { return; }
+    clock_indicate(WATCH_INDICATOR_PM, clock_is_pm(date_time));
+}
+
+static void clock_indicate_low_available_power(stock_clock_state_t *state) {
+    // Set the low battery indicator if battery power is low
+    if (watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM) {
+        // interlocking arrows imply "exchange" the battery.
+        clock_indicate(WATCH_INDICATOR_ARROWS, state->battery_low);
+    } else {
+        // LAP indicator on classic LCD is an adequate fallback.
+        clock_indicate(WATCH_INDICATOR_LAP, state->battery_low);
+    }
+}
+
+static watch_date_time_t clock_24h_to_12h(watch_date_time_t date_time) {
+    date_time.unit.hour %= 12;
+
+    if (date_time.unit.hour == 0) {
+        date_time.unit.hour = 12;
+    }
+
+    return date_time;
+}
+
+static void clock_check_battery_periodically(stock_clock_state_t *state, watch_date_time_t date_time) {
+    // check the battery voltage once a day
+    if (date_time.unit.day == state->last_battery_check) { return; }
+
+    state->last_battery_check = date_time.unit.day;
+
+    uint16_t voltage = watch_get_vcc_voltage();
+
+    state->battery_low = voltage < CLOCK_FACE_LOW_BATTERY_VOLTAGE_THRESHOLD;
+
+    clock_indicate_low_available_power(state);
+}
+
+static void clock_display_all(watch_date_time_t date_time) {
+    char buf[8 + 1];
+
+    snprintf(
+        buf,
+        sizeof(buf),
+        movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_024H ? "%02d%02d%02d%02d" : "%2d%2d%02d%02d",
+        date_time.unit.day,
+        date_time.unit.hour,
+        date_time.unit.minute,
+        date_time.unit.second
+    );
+
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, watch_utility_get_long_weekday(date_time), watch_utility_get_weekday(date_time));
+    watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf + 2);
+}
+
+static bool clock_display_some(watch_date_time_t current, watch_date_time_t previous) {
+    if ((current.reg >> 6) == (previous.reg >> 6)) {
+        // everything before seconds is the same, don't waste cycles setting those segments.
+
+        watch_display_character_lp_seconds('0' + current.unit.second / 10, 8);
+        watch_display_character_lp_seconds('0' + current.unit.second % 10, 9);
+
+        return true;
+
+    } else if ((current.reg >> 12) == (previous.reg >> 12)) {
+        // everything before minutes is the same.
+
+        char buf[4 + 1];
+
+        snprintf(
+            buf,
+            sizeof(buf),
+            "%02d%02d",
+            current.unit.minute,
+            current.unit.second
+        );
+
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+        watch_display_text(WATCH_POSITION_SECONDS, buf + 2);
+
+        return true;
+
+    } else {
+        // other stuff changed; let's do it all.
+        return false;
+    }
+}
+
+static void clock_display_clock(stock_clock_state_t *state, watch_date_time_t current) {
+    if (!clock_display_some(current, state->date_time.previous)) {
+        if (movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_12H) {
+            clock_indicate_pm(current);
+            current = clock_24h_to_12h(current);
+        }
+        clock_display_all(current);
+    }
+}
+
+static void clock_display_low_energy(watch_date_time_t date_time) {
+    if (movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_12H) {
+        clock_indicate_pm(date_time);
+        date_time = clock_24h_to_12h(date_time);
+    }
+    char buf[8 + 1];
+
+    snprintf(
+        buf,
+        sizeof(buf),
+        movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_024H ? "%02d%02d%02d  " : "%2d%2d%02d  ",
+        date_time.unit.day,
+        date_time.unit.hour,
+        date_time.unit.minute
+    );
+
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, watch_utility_get_long_weekday(date_time), watch_utility_get_weekday(date_time));
+    watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf + 2);
+}
+
+static void clock_start_tick_tock_animation(void) {
+    if (!watch_sleep_animation_is_running()) {
+        watch_start_sleep_animation(500);
+        watch_start_indicator_blink_if_possible(WATCH_INDICATOR_COLON, 500);
+    }
+}
+
+static void clock_stop_tick_tock_animation(void) {
+    if (watch_sleep_animation_is_running()) {
+        watch_stop_sleep_animation();
+        watch_stop_blink();
+    }
+}
+
+static void clock_toggle_clock_mode(void) {
+
+}
+
+void stock_clock_face_setup(uint8_t watch_face_index, void ** context_ptr) {
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stock_clock_state_t));
+        stock_clock_state_t *state = (stock_clock_state_t *) *context_ptr;
+        state->watch_face_index = watch_face_index;
+    }
+}
+
+void stock_clock_face_activate(void *context) {
+    stock_clock_state_t *state = (stock_clock_state_t *) context;
+
+    clock_stop_tick_tock_animation();
+
+    clock_indicate_time_signal();
+    clock_indicate_alarm();
+    clock_indicate_24h();
+
+    watch_set_colon();
+
+    // this ensures that none of the timestamp fields will match, so we can re-render them all.
+    state->date_time.previous.reg = 0xFFFFFFFF;
+}
+
+bool stock_clock_face_loop(movement_event_t event, void *context) {
+    stock_clock_state_t *state = (stock_clock_state_t *) context;
+    watch_date_time_t current;
+
+    switch (event.event_type) {
+        case EVENT_LOW_ENERGY_UPDATE:
+            clock_start_tick_tock_animation();
+            clock_display_low_energy(movement_get_local_date_time());
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            movement_set_clock_mode_24h(((movement_clock_mode_24h() + 1) % MOVEMENT_NUM_CLOCK_MODES));
+            clock_indicate_24h();
+            clock_indicate(WATCH_INDICATOR_PM, false);
+            // ensure we re-render fully
+            state->date_time.previous.reg = 0xFFFFFFFF;
+            // intentional fallthrough to redraw
+        case EVENT_TICK:
+        case EVENT_ACTIVATE:
+            current = movement_get_local_date_time();
+
+            clock_display_clock(state, current);
+
+            clock_check_battery_periodically(state, current);
+
+            state->date_time.previous = current;
+
+            break;
+
+        default:
+            return movement_default_loop_handler(event);
+    }
+
+    return true;
+}
+
+void stock_clock_face_resign(void *context) {
+    (void) context;
+}

--- a/watch-faces/clock/stock_clock_face.h
+++ b/watch-faces/clock/stock_clock_face.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * MIT License
+ *
+ * Copyright © 2021-2022 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 Alexsander Akers <me@a2.io>
+ * Copyright © 2022 TheOnePerson <a.nebinger@web.de>
+ * Copyright © 2023 Alex Utter <ooterness@gmail.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com>
+ * Copyright © 2025 Alessandro Genova
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef STOCK_CLOCK_FACE_H_
+#define STOCK_CLOCK_FACE_H_
+
+/*
+ * STOCK CLOCK FACE
+ *
+ * This is almost identical to clock_face, but it has two significant differences.
+ * - it delegates the playing of the hourly chime to another face, merely displaying the bell indicator
+ * - it toggles between 12/24H time display when pressing the alarm button
+ * 
+ * These changes effectively make this face identical to the stock F91W clock face, hence the name.
+ *
+ */
+
+#include "movement.h"
+
+typedef struct {
+    struct {
+        watch_date_time_t previous;
+    } date_time;
+    uint8_t last_battery_check;
+    uint8_t watch_face_index;
+    bool battery_low;
+} stock_clock_state_t;
+
+void stock_clock_face_setup(uint8_t watch_face_index, void ** context_ptr);
+void stock_clock_face_activate(void *context);
+bool stock_clock_face_loop(movement_event_t event, void *context);
+void stock_clock_face_resign(void *context);
+
+#define stock_clock_face ((const watch_face_t) { \
+    stock_clock_face_setup, \
+    stock_clock_face_activate, \
+    stock_clock_face_loop, \
+    stock_clock_face_resign, \
+    NULL, \
+})
+
+#endif // CLOCK_FACE_H_

--- a/watch-faces/complication/alarm_face.c
+++ b/watch-faces/complication/alarm_face.c
@@ -101,8 +101,10 @@ static void _alarm_face_update_indicators(alarm_face_state_t *state) {
 
     if ( chime_is_on(state) ) {
         watch_set_indicator(WATCH_INDICATOR_BELL);
+        movement_set_signal_enabled(true);
     } else {
         watch_clear_indicator(WATCH_INDICATOR_BELL);
+        movement_set_signal_enabled(false);
     }
 }
 

--- a/watch-faces/complication/alarm_face.c
+++ b/watch-faces/complication/alarm_face.c
@@ -35,18 +35,36 @@
 //
 
 static void _alarm_face_display_alarm_time(alarm_face_state_t *state) {
-    uint8_t hour = state->hour;
+    uint8_t hour = state->alarms[state->alarm_index].hour;
+    uint8_t minute = state->alarms[state->alarm_index].minute;
+    bool enabled = state->alarms[state->alarm_index].enabled;
 
-    if ( movement_clock_mode_24h() )
-        watch_set_indicator(WATCH_INDICATOR_24H);
-    else {
-        if ( hour >= 12 ) watch_set_indicator(WATCH_INDICATOR_PM);
-        else watch_clear_indicator(WATCH_INDICATOR_PM);
-        hour = hour % 12 ? hour % 12 : 12;
+    if (state->alarm_index == ALARM_FACE_SNOOZE_ALARM_INDEX) {
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
     }
 
     static char lcdbuf[7];
-    sprintf(lcdbuf, "%2d%02d  ", hour, state->minute);
+
+    if (state->alarm_index == ALARM_FACE_CHIME_INDEX) {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
+
+        sprintf(lcdbuf, "  %02d%s", minute, enabled ? "on" : "  ");
+    } else {
+        sprintf(lcdbuf, "%2d", state->alarm_index + 1);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, lcdbuf);
+
+        if ( movement_clock_mode_24h() )
+            watch_set_indicator(WATCH_INDICATOR_24H);
+        else {
+            if ( hour >= 12 ) watch_set_indicator(WATCH_INDICATOR_PM);
+            else watch_clear_indicator(WATCH_INDICATOR_PM);
+            hour = hour % 12 ? hour % 12 : 12;
+        }
+
+        sprintf(lcdbuf, "%2d%02d%s", hour, minute, enabled ? "on" : "  ");
+    }
 
     watch_display_text(WATCH_POSITION_BOTTOM, lcdbuf);
 }
@@ -54,6 +72,38 @@ static void _alarm_face_display_alarm_time(alarm_face_state_t *state) {
 static inline void button_beep() {
     // play a beep as confirmation for a button press (if applicable)
     if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+}
+
+static bool any_alarm_is_on(alarm_face_state_t *state) {
+    bool alarm_on = false;
+
+    for (uint8_t i = 0; i < ALARM_FACE_NUM_ALARMS; i++) {
+        if (i != ALARM_FACE_CHIME_INDEX) {
+            alarm_on = alarm_on || state->alarms[i].enabled;
+        }
+    }
+
+    return alarm_on;
+}
+
+static bool chime_is_on(alarm_face_state_t *state) {
+    return state->alarms[ALARM_FACE_CHIME_INDEX].enabled;
+}
+
+static void _alarm_face_update_indicators(alarm_face_state_t *state) {
+    if ( any_alarm_is_on(state) ) {
+        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+        movement_set_alarm_enabled(true);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+        movement_set_alarm_enabled(false);
+    }
+
+    if ( chime_is_on(state) ) {
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+    }
 }
 
 //
@@ -69,7 +119,9 @@ void alarm_face_setup(uint8_t watch_face_index, void **context_ptr) {
         memset(*context_ptr, 0, sizeof(alarm_face_state_t));
 
         // default to an 8:00 AM alarm time.
-        state->hour = 8;
+        for (uint8_t i = 0; i < ALARM_FACE_NUM_ALARMS; i++) {
+            state->alarms[i].hour = 8;
+        }
     }
 }
 
@@ -77,9 +129,19 @@ void alarm_face_activate(void *context) {
     alarm_face_state_t *state = (alarm_face_state_t *)context;
     state->setting_mode = ALARM_FACE_SETTING_MODE_NONE;
     state->quick_increase = 0;
+
+    // Don't play remaining snooze alarms if the user enters this face
+    state->next_snooze_alarm.hour = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].hour;
+    state->next_snooze_alarm.minute = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].minute;
+    state->remaining_snooze_repetitions = ALARM_FACE_SNOOZE_REPETITIONS;
 }
 void alarm_face_resign(void *context) {
-    (void) context;
+    alarm_face_state_t *state = (alarm_face_state_t *)context;
+
+    // Just in case we exit the alarm setting for the snooze alarm by pressing mode or timeout,
+    // sync up the next_snooze_alarm.
+    state->next_snooze_alarm.hour = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].hour;
+    state->next_snooze_alarm.minute = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].minute;
 }
 
 bool alarm_face_loop(movement_event_t event, void *context) {
@@ -88,7 +150,8 @@ bool alarm_face_loop(movement_event_t event, void *context) {
     switch (event.event_type) {
         case EVENT_ACTIVATE:
             watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "ALM", "AL");
-            if (state->alarm_is_on) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+            if (any_alarm_is_on(state)) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+            if ( chime_is_on(state) ) watch_set_indicator(WATCH_INDICATOR_BELL);
             watch_set_colon();
             _alarm_face_display_alarm_time(state);
             break;
@@ -102,7 +165,7 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                 case ALARM_FACE_SETTING_MODE_SETTING_HOUR:
                     if (state->quick_increase) {
                         // increment hour, wrap around to 0 at 23.
-                        state->hour = (state->hour + 1) % 24;
+                        state->alarms[state->alarm_index].hour = (state->alarms[state->alarm_index].hour + 1) % 24;
                         _alarm_face_display_alarm_time(state);
                     } else {
                         _alarm_face_display_alarm_time(state);
@@ -115,7 +178,7 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                 case ALARM_FACE_SETTING_MODE_SETTING_MINUTE:
                     if (state->quick_increase) {
                         // increment minute, wrap around to 0 at 59.
-                        state->minute = (state->minute + 1) % 60;
+                        state->alarms[state->alarm_index].minute = (state->alarms[state->alarm_index].minute + 1) % 60;
                         _alarm_face_display_alarm_time(state);
                     } else {
                         _alarm_face_display_alarm_time(state);
@@ -130,8 +193,8 @@ bool alarm_face_loop(movement_event_t event, void *context) {
         case EVENT_LIGHT_BUTTON_DOWN:
             switch (state->setting_mode) {
                 case ALARM_FACE_SETTING_MODE_NONE:
-                    // If we're not in a setting mode, turn on the LED like normal.
-                    movement_illuminate_led();
+                    state->alarm_index  = (state->alarm_index + 1) % ALARM_FACE_NUM_ALARMS;
+                    _alarm_face_display_alarm_time(state);
                     break;
                 case ALARM_FACE_SETTING_MODE_SETTING_HOUR:
                     // If we're setting the hour, advance to minute set mode.
@@ -143,47 +206,51 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                     movement_request_tick_frequency(1);
                     // beep to confirm setting.
                     button_beep();
-                    // also turn the alarm on since they just set it.
-                    state->alarm_is_on = 1;
-                    movement_set_alarm_enabled(true);
-                    watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+
+                    // If we just finished setting the snooze alarm, sync it up
+                    if (state->alarm_index == ALARM_FACE_SNOOZE_ALARM_INDEX) {
+                        state->next_snooze_alarm.hour = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].hour;
+                        state->next_snooze_alarm.minute = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].minute;
+                        state->remaining_snooze_repetitions = ALARM_FACE_SNOOZE_REPETITIONS;
+                    }
+
                     _alarm_face_display_alarm_time(state);
                     break;
-            }
-            break;
-        case EVENT_LIGHT_LONG_PRESS:
-            if (state->setting_mode == ALARM_FACE_SETTING_MODE_NONE) {
-                // long press in normal mode: move to hour setting mode, request fast tick.
-                state->setting_mode = ALARM_FACE_SETTING_MODE_SETTING_HOUR;
-                movement_request_tick_frequency(4);
-                button_beep();
             }
             break;
         case EVENT_ALARM_BUTTON_DOWN:
             switch (state->setting_mode) {
                 case ALARM_FACE_SETTING_MODE_NONE:
-                    state->alarm_is_on ^= 1;
-                    if ( state->alarm_is_on ) {
-                        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
-                    } else {
-                        watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
-                    }
+                    state->alarms[state->alarm_index].enabled ^= 1;
+                    _alarm_face_update_indicators(state);
 
-                    movement_set_alarm_enabled(state->alarm_is_on);
                     break;
                 case ALARM_FACE_SETTING_MODE_SETTING_HOUR:
                     // increment hour, wrap around to 0 at 23.
-                    state->hour = (state->hour + 1) % 24;
+                    state->alarms[state->alarm_index].hour = (state->alarms[state->alarm_index].hour + 1) % 24;
                     break;
                 case ALARM_FACE_SETTING_MODE_SETTING_MINUTE:
                     // increment minute, wrap around to 0 at 59.
-                    state->minute = (state->minute + 1) % 60;
+                    state->alarms[state->alarm_index].minute = (state->alarms[state->alarm_index].minute + 1) % 60;
                     break;
             }
             _alarm_face_display_alarm_time(state);
             break;
         case EVENT_ALARM_LONG_PRESS:
             switch (state->setting_mode) {
+                case ALARM_FACE_SETTING_MODE_NONE:
+                    if (state->alarm_index == ALARM_FACE_CHIME_INDEX) {
+                        state->setting_mode = ALARM_FACE_SETTING_MODE_SETTING_MINUTE;
+                    } else {
+                        state->setting_mode = ALARM_FACE_SETTING_MODE_SETTING_HOUR;
+                    }
+                    // also turn the alarm on since we are setting it.
+                    state->alarms[state->alarm_index].enabled = 1;
+                    _alarm_face_update_indicators(state);
+
+                    movement_request_tick_frequency(4);
+                    button_beep();
+                    break;
                 case ALARM_FACE_SETTING_MODE_SETTING_HOUR:
                 case ALARM_FACE_SETTING_MODE_SETTING_MINUTE:
                     state->quick_increase = 1;
@@ -205,8 +272,16 @@ bool alarm_face_loop(movement_event_t event, void *context) {
             }
             break;
         case EVENT_BACKGROUND_TASK:
-            movement_play_alarm();
+            if (state->play_alarm) {
+                movement_play_alarm();
                 // 2022-07-23: Thx @joeycastillo for the dedicated “alarm” signal
+            } else if (state->play_signal) {
+                movement_play_signal();
+            }
+
+            state->play_alarm = false;
+            state->play_signal = false;
+            
             break;
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
@@ -225,9 +300,48 @@ movement_watch_face_advisory_t alarm_face_advise(void *context) {
     alarm_face_state_t *state = (alarm_face_state_t *)context;
     movement_watch_face_advisory_t retval = { 0 };
 
-    if ( state->alarm_is_on ) {
+    if ( chime_is_on(state) || any_alarm_is_on(state) ) {
         watch_date_time_t now = movement_get_local_date_time();
-        retval.wants_background_task = (state->hour==now.unit.hour && state->minute==now.unit.minute);
+
+        bool play_alarm = false;
+        bool play_signal = false;
+
+        for (uint8_t i = 0; i < ALARM_FACE_NUM_ALARMS; i++) {
+            if (!state->alarms[i].enabled) {
+                continue;
+            }
+
+            if (i == ALARM_FACE_CHIME_INDEX) {
+                play_signal = state->alarms[ALARM_FACE_CHIME_INDEX].minute==now.unit.minute;
+            } else if (i == ALARM_FACE_SNOOZE_ALARM_INDEX) {
+                bool play_snooze_alarm = (state->next_snooze_alarm.hour==now.unit.hour && state->next_snooze_alarm.minute==now.unit.minute);
+                if (play_snooze_alarm) {
+                    state->remaining_snooze_repetitions -= 1;
+
+                    if (state->remaining_snooze_repetitions > 0) {
+                        // Repeate the snooze alarm in 5 minutes
+                        state->next_snooze_alarm.minute += ALARM_FACE_SNOOZE_DELAY;
+                        if (state->next_snooze_alarm.minute >= 60) {
+                            state->next_snooze_alarm.minute %= 60;
+                            state->next_snooze_alarm.hour += 1;
+                        }
+                    } else {
+                        // We have repeated the snooze alarms the max number allowed, don't play it again until tomorrow
+                        state->next_snooze_alarm.hour = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].hour;
+                        state->next_snooze_alarm.minute = state->alarms[ALARM_FACE_SNOOZE_ALARM_INDEX].minute;
+                        state->remaining_snooze_repetitions = ALARM_FACE_SNOOZE_REPETITIONS;
+                    }
+                }
+                play_alarm = play_alarm || play_snooze_alarm;
+            } else {
+                play_alarm = play_alarm || (state->alarms[i].hour==now.unit.hour && state->alarms[i].minute==now.unit.minute);
+            }
+        }
+
+        state->play_alarm = play_alarm;
+        state->play_signal = play_signal;
+
+        retval.wants_background_task = play_alarm || play_signal;
         // We’re at the mercy of the advise handler
         // In Safari, the emulator triggers at the ›end‹ of the minute
         // Converting to Unix timestamps and taking a difference between now and wake

--- a/watch-faces/complication/alarm_face.h
+++ b/watch-faces/complication/alarm_face.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2022 Josh Berson
  * Copyright (c) 2025 Joey Castillo
+ * Copyright (c) 2025 Alessandro Genova
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,14 +31,6 @@
  *
  * Basic daily alarm clock face. Seems useful if nothing else in the interest
  * of feature parity with the F-91W’s OEM module, 593.
- *
- * Also experiments with caret-free UI: One button cycles hours, the other
- * minutes, so there’s no toggling between display and adjust modes and no
- * cycling the caret through the UI.
- *   º LIGHT advances hour by 1
- *   º LIGHT long press advances hour by 6
- *   º ALARM advances minute by 10
- *   º ALARM long press cycles through signal modes (just one at the moment)
  */
 
 #include "movement.h"
@@ -53,6 +46,7 @@ typedef struct {
     uint32_t hour : 5;
     uint32_t minute : 6;
     uint32_t alarm_is_on : 1;
+    uint32_t quick_increase: 1;
     alarm_face_setting_mode_t setting_mode : 2;
 } alarm_face_state_t;
 

--- a/watch-faces/complication/alarm_face.h
+++ b/watch-faces/complication/alarm_face.h
@@ -27,7 +27,17 @@
 #pragma once
 
 /*
- * Daily ALARM face (formerly WAKE Face)
+ * Alarm Face modeled after the module in the GW-M5610U.
+ *
+ * This face is a port of the alarm face that can be found on more advanced Casios,
+ * with minor tweaks to make the UI work with 3 buttons instead of the typical 4.
+ * 
+ * In this face you can configure:
+ * - 4 daily alarms
+ * - 1 daily snooze alarm (will repeat 7 times at 5 minutes interval, unless the user enters the face)
+ * - 1 hourly chime
+ * 
+ * Bonus feature unique to this implementation, the hourly chime can be set for minutes other than :00.
  *
  * Basic daily alarm clock face. Seems useful if nothing else in the interest
  * of feature parity with the F-91W’s OEM module, 593.
@@ -42,12 +52,27 @@ typedef enum {
     ALARM_FACE_SETTING_MODE_SETTING_MINUTE
 } alarm_face_setting_mode_t;
 
+#define ALARM_FACE_NUM_ALARMS 6
+#define ALARM_FACE_SNOOZE_ALARM_INDEX (ALARM_FACE_NUM_ALARMS - 2)
+#define ALARM_FACE_CHIME_INDEX (ALARM_FACE_NUM_ALARMS - 1)
+#define ALARM_FACE_SNOOZE_DELAY 5
+#define ALARM_FACE_SNOOZE_REPETITIONS 7
+
 typedef struct {
     uint32_t hour : 5;
     uint32_t minute : 6;
-    uint32_t alarm_is_on : 1;
+    uint32_t enabled : 1;
+} alarm_face_alarm_t;
+
+typedef struct {
+    uint8_t alarm_index;
+    alarm_face_alarm_t alarms[ALARM_FACE_NUM_ALARMS];
+    alarm_face_alarm_t next_snooze_alarm;
+    uint8_t remaining_snooze_repetitions;
     uint32_t quick_increase: 1;
     alarm_face_setting_mode_t setting_mode : 2;
+    uint32_t play_alarm: 1;
+    uint32_t play_signal: 1;
 } alarm_face_state_t;
 
 void alarm_face_setup(uint8_t watch_face_index, void **context_ptr);


### PR DESCRIPTION
Ok, things got a bit out of hand in this PR, but the good thing is that each commit can be a useful addition on its own and we can merge them selectively if they are not all acceptable.

- First commit, basic improvements to `alarm_face`
  - hold down alarm button to quickly increase minutes/hours, instead of pressing each time
  - long press light button to enter edit mode, like the stock alarm and the majority of Casios
  - removed some incorrect user instructions from the header file
- Second commit: turn the `alarm_face` into a clone of the stock alarm face of more advanced Casios
   - 4 daily alarms
   - 1 daily snooze alarm (will repeat 7 times at 5 minutes interval, unless the user enters the face)
   - 1 hourly chime that can play at any minute, not just top of the hour, useful in some cases (e.g. doctors ending sessions at :45 and similar)
- Third commit: add `movement_signal_enabled()` and `movement_set_signal_enabled()`:
  - Just like we already have for the alarm, so a clock face can display the indicators
  - I know that `movement_alarm_enabled()` will be refactored, but in the meantime this is what we have
- Fourth commit: add an alternative clock face `stock_clock_face` that doesn't manage the hourly chime, but simply displays whether another face activated it or not (works great with the face from commit number 2).
  - This is 99% a copy of the original `clock_face`.
  - It is named "stock" because it behaves identically to the stock F91W clock face, including switching between 12/24 hr