### PR TITLE
Fixed capability to go to wake from sleep mode in simulator

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -494,6 +494,9 @@ void movement_request_sleep(void) {
 void movement_request_wake() {
     movement_volatile_state.exit_sleep_mode = true;
     _movement_reset_inactivity_countdown();
+#if __EMSCRIPTEN__
+    _wake_up_simulator();
+#endif
 }
 
 void cb_buzzer_start(void) {

--- a/watch-library/simulator/watch/watch_deepsleep.c
+++ b/watch-library/simulator/watch/watch_deepsleep.c
@@ -80,10 +80,6 @@ void watch_enter_sleep_mode(void) {
     // disable tick interrupt
     watch_rtc_disable_all_periodic_callbacks();
 
-    // // disable all buttons but alarm
-    watch_register_interrupt_callback(HAL_GPIO_BTN_MODE_pin(), NULL, INTERRUPT_TRIGGER_NONE);
-    watch_register_interrupt_callback(HAL_GPIO_BTN_LIGHT_pin(), NULL, INTERRUPT_TRIGGER_NONE);
-
     sleep(4);
 
     // call app_setup so the app can re-enable everything we disabled.


### PR DESCRIPTION
Simulator will now wake up when a button is pressed.
Issue was that the simulator needs to be woken up via a static bool that lives only in the simulator's deep-sleep file.