### PR TITLE
Added double-tapping, lower power usage, and explicitly setting the ISR to latched

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -976,18 +976,19 @@ bool movement_enable_tap_detection_if_available(void) {
     if (movement_state.has_lis2dw) {
         // configure tap duration threshold and enable Z axis
         lis2dw_configure_tap_threshold(0, 0, 12, LIS2DW_REG_TAP_THS_Z_Z_AXIS_ENABLE);
-        lis2dw_configure_tap_duration(10, 2, 2);
+        lis2dw_configure_tap_duration(2, 2, 2);
 
         // ramp data rate up to 400 Hz and high performance mode
         lis2dw_set_low_noise_mode(true);
         lis2dw_set_data_rate(LIS2DW_DATA_RATE_HP_400_HZ);
         lis2dw_set_mode(LIS2DW_MODE_HIGH_PERFORMANCE);
+        lis2dw_enable_double_tap();
 
         // Settling time (1 sample duration, i.e. 1/400Hz)
         delay_ms(3);
 
         // enable tap detection on INT1/A3.
-        lis2dw_configure_int1(LIS2DW_CTRL4_INT1_SINGLE_TAP | LIS2DW_CTRL4_INT1_6D);
+        lis2dw_configure_int1(LIS2DW_CTRL4_INT1_SINGLE_TAP | LIS2DW_CTRL4_INT1_DOUBLE_TAP | LIS2DW_CTRL4_INT1_6D);
 
         return true;
     }
@@ -1001,6 +1002,7 @@ bool movement_disable_tap_detection_if_available(void) {
         lis2dw_set_low_noise_mode(false);
         lis2dw_set_data_rate(movement_state.accelerometer_background_rate);
         lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
+        lis2dw_disable_double_tap();
         // ...disable Z axis (not sure if this is needed, does this save power?)...
         lis2dw_configure_tap_threshold(0, 0, 0, 0);
 

--- a/movement.c
+++ b/movement.c
@@ -981,7 +981,7 @@ bool movement_enable_tap_detection_if_available(void) {
         // ramp data rate up to 400 Hz and high performance mode
         lis2dw_set_low_noise_mode(true);
         lis2dw_set_data_rate(LIS2DW_DATA_RATE_HP_400_HZ);
-        lis2dw_set_mode(LIS2DW_MODE_HIGH_PERFORMANCE);
+        lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
         lis2dw_enable_double_tap();
 
         // Settling time (1 sample duration, i.e. 1/400Hz)

--- a/movement.c
+++ b/movement.c
@@ -285,12 +285,12 @@ static uint32_t _movement_get_accelerometer_events() {
 
     if (int_src & LIS2DW_REG_ALL_INT_SRC_DOUBLE_TAP) {
         accelerometer_events |= 1 << EVENT_DOUBLE_TAP;
-        printf("Double tap!\n");
+        printf("Double tap!\r\n");
     }
 
     if (int_src & LIS2DW_REG_ALL_INT_SRC_SINGLE_TAP) {
         accelerometer_events |= 1 << EVENT_SINGLE_TAP;
-        printf("Single tap!\n");
+        printf("Single tap!\r\n");
     }
 
     return accelerometer_events;
@@ -1292,6 +1292,7 @@ void app_setup(void) {
             watch_register_interrupt_callback(HAL_GPIO_A3_pin(), cb_accelerometer_event, INTERRUPT_TRIGGER_RISING);
 
             // Enable the interrupts...
+            lis2dw_latched_interrupts();
             lis2dw_enable_interrupts();
 
             // At first boot, this next line sets the accelerometer's sampling rate to 0, which is LIS2DW_DATA_RATE_POWERDOWN.

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -302,6 +302,20 @@ void lis2dw_clear_fifo(void) {
 #endif
 }
 
+void lis2dw_enable_double_tap(void) {
+#ifdef I2C_SERCOM
+    uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_WAKE_UP_THS);
+    watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_WAKE_UP_THS, configuration | LIS2DW_WAKE_UP_THS_ENABLE_DOUBLE_TAP);
+#endif
+}
+
+void lis2dw_disable_double_tap(void) {
+#ifdef I2C_SERCOM
+    uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_WAKE_UP_THS);
+    watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_WAKE_UP_THS, configuration & ~LIS2DW_WAKE_UP_THS_ENABLE_DOUBLE_TAP);
+#endif
+}
+
 void lis2dw_enable_sleep(void) {
 #ifdef I2C_SERCOM
     uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_WAKE_UP_THS);

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -425,6 +425,20 @@ void lis2dw_disable_interrupts(void) {
 #endif
 }
 
+void lis2dw_pulsed_interrupts(void) {
+#ifdef I2C_SERCOM
+    uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7);
+    watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7, configuration | LIS2DW_CTRL7_VAL_DRDY_PULSED);
+#endif
+}
+
+void lis2dw_latched_interrupts(void) {
+#ifdef I2C_SERCOM
+    uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7);
+    watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7, configuration & ~LIS2DW_CTRL7_VAL_DRDY_PULSED);
+#endif
+}
+
 lis2dw_wakeup_source_t lis2dw_get_wakeup_source() {
 #ifdef I2C_SERCOM
     return (lis2dw_wakeup_source_t) watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_WAKE_UP_SRC);

--- a/watch-library/shared/driver/lis2dw.h
+++ b/watch-library/shared/driver/lis2dw.h
@@ -343,6 +343,10 @@ bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data);
 
 void lis2dw_clear_fifo(void);
 
+void lis2dw_enable_double_tap(void);
+
+void lis2dw_disable_double_tap(void);
+
 void lis2dw_enable_sleep(void);
 
 void lis2dw_disable_sleep(void);

--- a/watch-library/shared/driver/lis2dw.h
+++ b/watch-library/shared/driver/lis2dw.h
@@ -375,6 +375,10 @@ void lis2dw_enable_interrupts(void);
 
 void lis2dw_disable_interrupts(void);
 
+void lis2dw_pulsed_interrupts(void);
+
+void lis2dw_latched_interrupts(void);
+
 lis2dw_interrupt_source_t lis2dw_get_interrupt_source(void);
 
 lis2dw_wakeup_source_t lis2dw_get_wakeup_source(void);


### PR DESCRIPTION
1. [Double tapping now works](https://github.com/joeycastillo/second-movement/pull/149)
2. [Tapping uses much less power.](https://github.com/joeycastillo/second-movement/pull/148)
3. While not needed as the app notes state the chip uses the latched DRDY type by default, we'll explicitly set it.