### PR TITLE
Rtc counter32 accel fixes

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -818,6 +818,7 @@ bool movement_enable_tap_detection_if_available(void) {
         lis2dw_set_data_rate(LIS2DW_DATA_RATE_HP_400_HZ);
         lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
         lis2dw_enable_double_tap();
+        lis2dw12_int_notification_set(LIS2DW12_INT_LATCHED);
 
         // Settling time (1 sample duration, i.e. 1/400Hz)
         delay_ms(3);
@@ -838,6 +839,7 @@ bool movement_disable_tap_detection_if_available(void) {
         lis2dw_set_data_rate(movement_state.accelerometer_background_rate);
         lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
         lis2dw_disable_double_tap();
+        lis2dw12_int_notification_set(LIS2DW12_INT_PULSED);
         // ...disable Z axis (not sure if this is needed, does this save power?)...
         lis2dw_configure_tap_threshold(0, 0, 0, 0);
 
@@ -1114,7 +1116,6 @@ void app_setup(void) {
             watch_register_interrupt_callback(HAL_GPIO_A3_pin(), cb_accelerometer_event, INTERRUPT_TRIGGER_RISING);
 
             // Enable the interrupts...
-            lis2dw_latched_interrupts();
             lis2dw_enable_interrupts();
 
             // At first boot, this next line sets the accelerometer's sampling rate to 0, which is LIS2DW_DATA_RATE_POWERDOWN.

--- a/movement.c
+++ b/movement.c
@@ -279,20 +279,10 @@ static void _movement_renew_top_of_minute_alarm(void) {
     movement_volatile_state.schedule_next_comp = true;
 }
 
-#define PRINT_LIS_EVENTS false
 static uint32_t _movement_get_accelerometer_events() {
     uint32_t accelerometer_events = 0;
 
     uint8_t int_src = lis2dw_get_interrupt_source();
-#if PRINT_LIS_EVENTS
-    printf("_movement_get_accelerometer_events\r\n");
-    if (int_src & LIS2DW_REG_ALL_INT_SRC_SLEEP_CHANGE_IA)  printf("Sleep Change IA\r\n");
-    if (int_src & LIS2DW_REG_ALL_INT_SRC_6D_IA)            printf("6D IA\r\n");
-    if (int_src & LIS2DW_REG_ALL_INT_SRC_SINGLE_TAP)       printf("Single Tap\r\n");
-    if (int_src & LIS2DW_REG_ALL_INT_SRC_DOUBLE_TAP)       printf("Double Tap\r\n");
-    if (int_src & LIS2DW_REG_ALL_INT_SRC_WU_IA)            printf("Wake Up\r\n");
-    if (int_src & LIS2DW_REG_ALL_INT_SRC_FF_IA)            printf("Free Fall\r\n");
-#endif
 
     if (int_src & LIS2DW_REG_ALL_INT_SRC_DOUBLE_TAP) {
         accelerometer_events |= 1 << EVENT_DOUBLE_TAP;

--- a/movement.c
+++ b/movement.c
@@ -818,7 +818,6 @@ bool movement_enable_tap_detection_if_available(void) {
         lis2dw_set_data_rate(LIS2DW_DATA_RATE_HP_400_HZ);
         lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
         lis2dw_enable_double_tap();
-        lis2dw12_int_notification_set(LIS2DW12_INT_LATCHED);
 
         // Settling time (1 sample duration, i.e. 1/400Hz)
         delay_ms(3);
@@ -839,7 +838,6 @@ bool movement_disable_tap_detection_if_available(void) {
         lis2dw_set_data_rate(movement_state.accelerometer_background_rate);
         lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
         lis2dw_disable_double_tap();
-        lis2dw12_int_notification_set(LIS2DW12_INT_PULSED);
         // ...disable Z axis (not sure if this is needed, does this save power?)...
         lis2dw_configure_tap_threshold(0, 0, 0, 0);
 

--- a/movement.c
+++ b/movement.c
@@ -833,7 +833,7 @@ bool movement_enable_tap_detection_if_available(void) {
         delay_ms(3);
 
         // enable tap detection on INT1/A3.
-        lis2dw_configure_int1(LIS2DW_CTRL4_INT1_SINGLE_TAP | LIS2DW_CTRL4_INT1_DOUBLE_TAP | LIS2DW_CTRL4_INT1_6D);
+        lis2dw_configure_int1(LIS2DW_CTRL4_INT1_SINGLE_TAP | LIS2DW_CTRL4_INT1_DOUBLE_TAP);
 
         return true;
     }

--- a/movement.c
+++ b/movement.c
@@ -279,10 +279,20 @@ static void _movement_renew_top_of_minute_alarm(void) {
     movement_volatile_state.schedule_next_comp = true;
 }
 
+#define PRINT_LIS_EVENTS false
 static uint32_t _movement_get_accelerometer_events() {
     uint32_t accelerometer_events = 0;
 
     uint8_t int_src = lis2dw_get_interrupt_source();
+#if PRINT_LIS_EVENTS
+    printf("_movement_get_accelerometer_events\r\n");
+    if (int_src & LIS2DW_REG_ALL_INT_SRC_SLEEP_CHANGE_IA)  printf("Sleep Change IA\r\n");
+    if (int_src & LIS2DW_REG_ALL_INT_SRC_6D_IA)            printf("6D IA\r\n");
+    if (int_src & LIS2DW_REG_ALL_INT_SRC_SINGLE_TAP)       printf("Single Tap\r\n");
+    if (int_src & LIS2DW_REG_ALL_INT_SRC_DOUBLE_TAP)       printf("Double Tap\r\n");
+    if (int_src & LIS2DW_REG_ALL_INT_SRC_WU_IA)            printf("Wake Up\r\n");
+    if (int_src & LIS2DW_REG_ALL_INT_SRC_FF_IA)            printf("Free Fall\r\n");
+#endif
 
     if (int_src & LIS2DW_REG_ALL_INT_SRC_DOUBLE_TAP) {
         accelerometer_events |= 1 << EVENT_DOUBLE_TAP;

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -411,6 +411,33 @@ void lis2dw_configure_int2(uint8_t sources) {
 #endif
 }
 
+void lis2dw12_int_notification_set(lis2dw12_lir_t val) {
+#ifdef I2C_SERCOM
+    uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL3);
+    if (val == LIS2DW12_INT_LATCHED) {
+        configuration |= LIS2DW_CTRL3_VAL_LIR;
+    } else {
+        configuration &= ~LIS2DW_CTRL7_VAL_DRDY_PULSED;
+    }
+    watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL3, configuration);
+#else
+    (void)val;
+#endif
+}
+
+lis2dw12_lir_t lis2dw12_int_notification_get(void) {
+#ifdef I2C_SERCOM
+    uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL3);
+    if (configuration & LIS2DW12_INT_LATCHED) {
+        return LIS2DW12_INT_LATCHED;
+    } else {
+        return LIS2DW12_INT_PULSED;
+    }
+#else
+    return LIS2DW12_INT_PULSED;
+#endif
+}
+
 void lis2dw_enable_interrupts(void) {
 #ifdef I2C_SERCOM
     uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7);
@@ -425,14 +452,14 @@ void lis2dw_disable_interrupts(void) {
 #endif
 }
 
-void lis2dw_pulsed_interrupts(void) {
+void lis2dw_pulsed_drdy_interrupts(void) {
 #ifdef I2C_SERCOM
     uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7);
     watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7, configuration | LIS2DW_CTRL7_VAL_DRDY_PULSED);
 #endif
 }
 
-void lis2dw_latched_interrupts(void) {
+void lis2dw_latched_drdy_interrupts(void) {
 #ifdef I2C_SERCOM
     uint8_t configuration = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7);
     watch_i2c_write8(LIS2DW_ADDRESS, LIS2DW_REG_CTRL7, configuration & ~LIS2DW_CTRL7_VAL_DRDY_PULSED);

--- a/watch-library/shared/driver/lis2dw.h
+++ b/watch-library/shared/driver/lis2dw.h
@@ -92,6 +92,12 @@ typedef enum {
   LIS2DW_FILTER_HIGH_PASS = 1,
 } lis2dw_filter_t;
 
+typedef enum
+{
+  LIS2DW12_INT_PULSED   = 0,
+  LIS2DW12_INT_LATCHED  = 1,
+} lis2dw12_lir_t;
+
 typedef enum {
   LIS2DW_RANGE_16_G = 0b11, // +/- 16g
   LIS2DW_RANGE_8_G = 0b10,  // +/- 8g
@@ -367,6 +373,10 @@ void lis2dw_configure_tap_threshold(uint8_t threshold_x, uint8_t threshold_y, ui
 
 void lis2dw_configure_tap_duration(uint8_t latency, uint8_t quiet, uint8_t shock);
 
+void lis2dw12_int_notification_set(lis2dw12_lir_t val);
+
+lis2dw12_lir_t lis2dw12_int_notification_get(void);
+
 void lis2dw_configure_int1(uint8_t sources);
 
 void lis2dw_configure_int2(uint8_t sources);
@@ -375,9 +385,9 @@ void lis2dw_enable_interrupts(void);
 
 void lis2dw_disable_interrupts(void);
 
-void lis2dw_pulsed_interrupts(void);
+void lis2dw_pulsed_drdy_interrupts(void);
 
-void lis2dw_latched_interrupts(void);
+void lis2dw_latched_drdy_interrupts(void);
 
 lis2dw_interrupt_source_t lis2dw_get_interrupt_source(void);
 


### PR DESCRIPTION
After finding that Latched mode on DRDY differs from LIR, I implemented LIR.
I then found that LIR causes the watch to miss double-taps, so i reverted pulsed interrupt.
It seems to work welll.